### PR TITLE
Add cmake option to setup _WIN32_WINNT value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ option( CPP-NETLIB_ENABLE_HTTPS "Build cpp-netlib with support for https if Open
 option( CPP-NETLIB_STATIC_OPENSSL "Build cpp-netlib using static OpenSSL" OFF)
 option( CPP-NETLIB_STATIC_BOOST "Build cpp-netlib using static Boost" OFF)
 
+if (NOT DEFINED CPP-NETLIB_WINAPI_VERSION)
+  set(CPP-NETLIB_WINAPI_VERSION 0x0501)
+endif()
+
 include(GNUInstallDirs)
 
 # determine install path for CMake config files
@@ -116,7 +120,7 @@ endif()
 
 
 if (WIN32)
-  target_compile_definitions(cppnetlib INTERFACE _WIN32_WINNT=0x0501)
+  target_compile_definitions(cppnetlib INTERFACE _WIN32_WINNT=${CPP-NETLIB_WINAPI_VERSION} BOOST_USE_WINAPI_VERSION=${CPP-NETLIB_WINAPI_VERSION})
 
   if (MSVC)
     target_compile_options(cppnetlib INTERFACE /bigobj)


### PR DESCRIPTION
I've added `CPP-NETLIB_WINAPI_VERSION` cmake options.

This option allows us to setup `_WIN32_WINNT` definition value from cmake command line
Default value is 0x0501 (`_WIN32_WINNT_WINXP`)
https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt

This option allows to solve linking issues with [Boost::Log](https://www.boost.org/doc/libs/1_66_0/libs/log/doc/html/log/rationale/namespace_mangling.html) on Windows

For example, binaries for windows published on [www.boost.org](https://www.boost.org/doc/libs/1_66_0/libs/log/doc/html/index.html) are built with `_WIN32_WINNT` > 0x0600.